### PR TITLE
Add minion missing test

### DIFF
--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -18,6 +18,8 @@ class Minion < ApplicationRecord
       salt.assign_role role: role
     end
     true
+  rescue Pharos::SaltApi::SaltConnectionException
+    false
   end
   # rubocop:enable SkipsModelValidations
 

--- a/spec/lib/pharos/salt_api_spec.rb
+++ b/spec/lib/pharos/salt_api_spec.rb
@@ -27,4 +27,14 @@ describe Pharos::SaltApi do
       end
     end
   end
+
+  context "when a HTTP/socket error happens" do
+    before { allow(Net::HTTP).to receive(:start) { raise Errno::ECONNREFUSED } }
+
+    it "raises SaltConnectionException" do
+      expect do
+        salt_api.perform_request(endpoint: "/minions/minion1", method: "get")
+      end.to raise_error(Pharos::SaltApi::SaltConnectionException)
+    end
+  end
 end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -33,10 +33,14 @@ describe Minion do
 
     context "role fails to be assigned on the remote" do
       before do
-        allow(minion.salt).to receive(:assign_role) { raise Net::HTTPBadResponse }
+        allow(minion.salt).to receive(:assign_role) do
+          raise Pharos::SaltApi::SaltConnectionException
+        end
       end
 
-      it "saves the role locally" do
+      it "does not save the role in the database" do
+        expect(minion.assign_role(role: :master)).to be false
+        expect(minion.reload.role).to be_nil
       end
     end
   end


### PR DESCRIPTION
If we cannot set the role on the remote, make sure that the transaction
gets a rollback, so we have the same information on the local database
than the remote salt instance.