### PR TITLE
Remove envvars from specific tests

### DIFF
--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe NodesController, type: :controller do
   let(:user)   { create(:user)   }
   let(:minion) { create(:minion) }
 
-  before do
-    ENV["PHAROS_SALT_HOST"] = "127.0.0.1"
-    ENV["PHAROS_SALT_PORT"] = "8000"
-  end
-
   describe "GET /nodes" do
     it "gets redirected if not logged in" do
       get :index

--- a/spec/lib/pharos/salt_api_spec.rb
+++ b/spec/lib/pharos/salt_api_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 require "pharos/salt"
 
 describe Pharos::SaltApi do
-  before do
-    ENV["PHAROS_SALT_HOST"] = "127.0.0.1"
-    ENV["PHAROS_SALT_PORT"] = "8000"
-  end
-
   let(:salt_api) { Class.new { include Pharos::SaltApi } }
 
   it "the instance responds to token" do

--- a/spec/lib/pharos/salt_minion_spec.rb
+++ b/spec/lib/pharos/salt_minion_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 require "pharos/salt_minion"
 
 describe Pharos::SaltMinion do
-  before do
-    ENV["PHAROS_SALT_HOST"] = "127.0.0.1"
-    ENV["PHAROS_SALT_PORT"] = "8000"
-  end
-
   describe "minions" do
     it "fetches a single minion" do
       VCR.use_cassette("salt/fetch_minion", record: :none) do

--- a/spec/lib/pharos/salt_spec.rb
+++ b/spec/lib/pharos/salt_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 require "pharos/salt"
 
 describe Pharos::Salt do
-  before do
-    ENV["PHAROS_SALT_HOST"] = "127.0.0.1"
-    ENV["PHAROS_SALT_PORT"] = "8000"
-  end
-
   describe "call" do
     it "returns the bare response object and its parsed body" do
       VCR.use_cassette("salt/request_no_args", record: :none) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,5 +27,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before :all do
+    ENV["PHAROS_SALT_HOST"] ||= "127.0.0.1"
+    ENV["PHAROS_SALT_PORT"] ||= "8000"
+  end
+
   config.order = :random
 end


### PR DESCRIPTION
Instead, set them on the spec_helper, so we ensure that we aren't
missing this envvars that will help us to mock requests with VCR.