### PR TITLE
Check that we are trying to reassign available roles if they fail

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -22,14 +22,12 @@ class NodesController < ApplicationController
   # assigned role, assign a random role to it, and then call the salt
   # orchestration.
   def bootstrap
-    available_roles = [:master]
+    @available_roles = [:master]
     Minion.where(role: nil).find_each do |minion|
-      random_role = if available_roles.blank?
-        :minion
-      else
-        available_roles.delete_at(rand(available_roles.length))
+      random_role = @available_roles.pop || :minion
+      unless minion.assign_role(role: random_role)
+        @available_roles << random_role if random_role != :minion
       end
-      minion.assign_role(role: random_role)
     end
     Pharos::Salt.orchestrate
     redirect_to nodes_path

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -95,5 +95,19 @@ RSpec.describe NodesController, type: :controller do
       end
       expect(response.status).to eq 302
     end
+
+    context "a role fails to be assigned" do
+      # rubocop:disable AnyInstance
+      before do
+        allow_any_instance_of(Minion).to receive(:assign_role).and_return(false)
+      end
+      # rubocop:enable AnyInstance
+      it "retries to assign this role" do
+        VCR.use_cassette("salt/bootstrap", record: :none) do
+          post :bootstrap
+        end
+        expect(assigns(:available_roles).length).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
If we have certain roles to be assigned (mandatory, not `minion` ones). We should retry to assign them if a previous assignment fails.