### PR TITLE
Create assign_roles method on Minion and remove keyword args

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
     gem "rubocop", "~> 0.46", require: false
     gem "brakeman", require: false
     gem "database_cleaner"
+    gem "pry"
+    gem "pry-nav"
   end
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     cliver (0.3.2)
     codeclimate-test-reporter (1.0.5)
       simplecov
+    coderay (1.1.1)
     concurrent-ruby (1.0.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -145,6 +146,12 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     public_suffix (2.0.5)
     puma (3.6.2)
     rack (2.0.1)
@@ -240,6 +247,7 @@ GEM
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
+    slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -302,6 +310,8 @@ DEPENDENCIES
   listen
   mysql2
   poltergeist
+  pry
+  pry-nav
   puma (~> 3.0)
   rails (~> 5.0.0)
   rails-controller-testing

--- a/app/models/minion.rb
+++ b/app/models/minion.rb
@@ -4,18 +4,43 @@ require "pharos/salt_minion"
 
 # Minion represents the minions that have been registered in this application.
 class Minion < ApplicationRecord
+  class NotEnoughMinions < StandardError; end
+  class CouldNotAssignRole < StandardError; end
+
   enum role: [:master, :minion]
 
   validates :hostname, uniqueness: true
 
+  # This method is used to assign the specified roles to Minions which do not
+  # have a roles already assigned (available minions).
+  # roles param are the roles we absolutely have to assign. If we can't assign
+  # one of those, the method will raise.
+  # default_role param can be set if we want all the rest of the available
+  # minions to get a default role.
+  def self.assign_roles(roles: [], default_role: nil)
+    minions = Minion.where(role: nil)
+
+    # only the needed number of minions or all if we have a default role
+    minions = minions.limit(roles.size) unless default_role
+
+    raise NotEnoughMinions if minions.count < roles.size
+
+    minions.find_each do |minion|
+      unless minion.assign_role(roles.pop || default_role)
+        raise CouldNotAssignRole
+      end
+    end
+  end
+
   # rubocop:disable SkipsModelValidations
   # Assigns a role to this minion locally in the database, and send that role
   # to salt subsystem.
-  def assign_role(role:)
-    return false if salt.roles?
+  def assign_role(new_role)
+    return false if role.present?
+
     Minion.transaction do
-      update_column :role, role
-      salt.assign_role role: role
+      update_column :role, new_role
+      salt.assign_role new_role
     end
     true
   rescue Pharos::SaltApi::SaltConnectionException

--- a/lib/pharos/salt_minion.rb
+++ b/lib/pharos/salt_minion.rb
@@ -30,8 +30,9 @@ module Pharos
     end
 
     # Assign role to this minion.
-    def assign_role(role:)
+    def assign_role(role)
       append_grain key: "roles", val: ROLES_MAP[role]
+
       role
     end
 

--- a/spec/lib/pharos/salt_minion_spec.rb
+++ b/spec/lib/pharos/salt_minion_spec.rb
@@ -29,7 +29,7 @@ describe Pharos::SaltMinion do
 
       it "assigns a role when called assign_role" do
         VCR.use_cassette("salt/assign_role_to_minion", record: :none) do
-          expect(described_class.new(minion_id: "minion1").assign_role(role: :master)).to eq :master
+          expect(described_class.new(minion_id: "minion1").assign_role(:master)).to eq :master
         end
       end
     end

--- a/spec/models/minion_spec.rb
+++ b/spec/models/minion_spec.rb
@@ -2,33 +2,93 @@
 require "rails_helper"
 
 describe Minion do
-  subject(:minion) { create(:minion) }
-  before           { allow(minion.salt).to receive(:assign_role) { true } }
-
   it { is_expected.to validate_uniqueness_of(:hostname) }
 
-  context "with some salt roles assigned" do
-    before { allow(minion.salt).to receive(:roles?) { true } }
-
-    it "returns false when calling assign_role" do
-      expect(minion.assign_role(role: :master)).to be false
+  describe ".assign_roles" do
+    let(:minions) do
+      FactoryGirl.create_list(:minion, 3, role: nil)
     end
 
-    it "does not update the role in the database" do
-      expect(minion.role).to be_nil
+    context "when there are not enough Minions" do
+      it "raises NotEnoughMinions" do
+        expect { described_class.assign_roles(roles: [:master, :minion]) }
+          .to raise_error(Minion::NotEnoughMinions)
+      end
+    end
+
+    context "when a role cannot be assigned" do
+      before do
+        minions
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(described_class).to receive(:assign_role).and_return(false)
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "raises CouldNotAssignRole" do
+        expect { described_class.assign_roles(roles: [:master]) }
+          .to raise_error(Minion::CouldNotAssignRole)
+      end
+    end
+
+    context "when default_role is set" do
+      before do
+        minions
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Pharos::SaltMinion).to receive(:assign_role)
+          .and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "assigns the default role to the rest of the available minions" do
+        described_class.assign_roles(roles: [:master], default_role: :minion)
+
+        expect(described_class.all.map(&:role).sort).to eq(["master", "minion", "minion"])
+      end
+    end
+
+    context "when default_role is not set" do
+      before do
+        minions
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Pharos::SaltMinion).to receive(:assign_role)
+          .and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "assigns the default role to the rest of the available minions" do
+        described_class.assign_roles(roles: [:master])
+
+        expect(described_class.all.map(&:role)).to eq(["master", nil, nil])
+      end
     end
   end
 
-  context "with no salt roles assigned" do
-    before { allow(minion.salt).to receive(:roles?) { false } }
+  context "with some roles assigned" do
+    let(:minion) { create(:minion, role: :master) }
+
+    before { allow(minion.salt).to receive(:assign_role) { true } }
+
+    it "returns false when calling assign_role" do
+      expect(minion.assign_role(:other_role)).to be false
+    end
+
+    it "does not update the role in the database" do
+      expect(minion.role).to eq("master")
+    end
+  end
+
+  context "with no roles assigned" do
+    let(:minion) { create(:minion, role: nil) }
+
+    before { allow(minion.salt).to receive(:assign_role) { true } }
 
     it "returns true when calling assign_role" do
-      expect(minion.assign_role(role: :master)).to be true
+      expect(minion.reload.assign_role(:master)).to be true
     end
 
     it "updates the role in the database" do
-      minion.assign_role role: :master
-      expect(minion.role).to eq("master")
+      minion.assign_role(:master)
+      expect(minion.reload.role).to eq("master")
     end
 
     context "role fails to be assigned on the remote" do
@@ -39,7 +99,7 @@ describe Minion do
       end
 
       it "does not save the role in the database" do
-        expect(minion.assign_role(role: :master)).to be false
+        expect(minion.assign_role(:master)).to be false
         expect(minion.reload.role).to be_nil
       end
     end


### PR DESCRIPTION
Also trust our database and don't query salt for already applied roles