### PR TITLE
Update the salt interface to take action and a default targets: '*'

### DIFF
--- a/lib/pharos/salt.rb
+++ b/lib/pharos/salt.rb
@@ -7,14 +7,13 @@ module Pharos
     include SaltApi
 
     # This method is the entrypoint of any Salt call. It will simply apply the
-    # given function 'fun' with the given arguments 'arg' to the given target
-    # machines.
+    # given function 'action' with the given arguments 'arg' to the given targets.
     #
     # Returns two values:
     #   - The response object.
     #   - A hash containing the parsed JSON response.
-    def self.call(tgt:, fun:, arg: nil)
-      hsh = { tgt: tgt, fun: fun, client: "local" }
+    def self.call(action:, targets: "*", arg: nil)
+      hsh = { tgt: targets, fun: action, client: "local" }
       hsh[:arg] = arg if arg
 
       res = perform_request(endpoint: "/", method: "post", data: hsh)

--- a/spec/lib/pharos/salt_spec.rb
+++ b/spec/lib/pharos/salt_spec.rb
@@ -6,14 +6,14 @@ describe Pharos::Salt do
   describe "call" do
     it "returns the bare response object and its parsed body" do
       VCR.use_cassette("salt/request_no_args", record: :none) do
-        res, hsh = described_class.call(tgt: "*", fun: "test.ping")
+        res, hsh = described_class.call(action: "test.ping")
         expect(hsh).to eq JSON.parse(res.body)
       end
     end
 
     it "performs a request with no arguments" do
       VCR.use_cassette("salt/request_no_args", record: :none) do
-        _, hsh = described_class.call(tgt: "*", fun: "test.ping")
+        _, hsh = described_class.call(action: "test.ping")
         expect(hsh["return"][0]["local"]).to be_truthy
       end
     end


### PR DESCRIPTION
This exposes less salt slang to the Pharos::Salt users.